### PR TITLE
Update dotnet core sdk to 2.1.3

### DIFF
--- a/src/Microsoft.PowerShell.SHiPS/Microsoft.PowerShell.SHiPS.csproj
+++ b/src/Microsoft.PowerShell.SHiPS/Microsoft.PowerShell.SHiPS.csproj
@@ -8,8 +8,7 @@
     <AssemblyOriginatorKeyFile>../signing/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PackageId>Microsoft.PowerShell.SHiPS</PackageId>
-    <RuntimeIdentifiers>win7-x64;win81-x64;win10-x64</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <RuntimeIdentifiers>win7-x64;win81-x64;win10-x64</RuntimeIdentifiers>	
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>

--- a/src/bootstrap.ps1
+++ b/src/bootstrap.ps1
@@ -24,7 +24,7 @@ function Start-DotnetBootstrap
     [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='High')]
     param(
         [string]$Channel = 'preview',
-        [string]$Version = '2.0.0-preview2-006388'              
+        [string]$Version = '2.1.3'              
     )
 
     # Install ours and .NET's dependencies


### PR DESCRIPTION
I've removed the now obsolete PackageTargetFallback element from the csproj file:
See also: https://stackoverflow.com/questions/45569378/upgrading-to-net-core-2-0-packagetargetfallback-and-assettargetfallback-cannot
