### PR TITLE
Explictily throw NotSupport for commands - Get/Set/Clea- Content, Move/Copy/New/Remove/Rename/Clear/Set-Item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+###
+SHiPS Specific
+###
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+out/
+
+# Visual Studio 2015 cache/options directory
+.vs/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUNIT
+*.VisualState.xml
+test/*[Tt]est[Rr]esults.xml
+test/automation/*[Tt]est[Rr]esults.xml
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+**/Properties/launchSettings.json
+
+# Auto generated
+tools/install-powershell.ps1

--- a/src/Microsoft.PowerShell.SHiPS/Node/NodeServiceBase.cs
+++ b/src/Microsoft.PowerShell.SHiPS/Node/NodeServiceBase.cs
@@ -1,0 +1,33 @@
+﻿using CodeOwls.PowerShell.Provider.PathNodes;
+
+namespace Microsoft.PowerShell.SHiPS
+{
+    /// <summary>
+    /// Defines actions that applies to a SHiPSLeaf node.
+    /// </summary>
+    internal class LeafNodeService : PathNodeBase
+    {
+        private readonly SHiPSLeaf _shipsLeaf;
+        private static readonly string _leaf = ".";
+
+        internal LeafNodeService(object leafObject)
+        {
+            _shipsLeaf = leafObject as SHiPSLeaf;
+        }
+
+        public override IPathValue GetNodeValue()
+        {
+            return new LeafPathValue(_shipsLeaf, Name);
+        }
+
+        public override string ItemMode
+        {
+            get {return _leaf; }
+        }
+
+        public override string Name
+        {
+            get { return _shipsLeaf.Name; }
+        }
+    }
+}

--- a/src/Microsoft.PowerShell.SHiPS/SHiPSConstants.cs
+++ b/src/Microsoft.PowerShell.SHiPS/SHiPSConstants.cs
@@ -8,7 +8,8 @@
         internal static readonly string RootNodeTypeMustBeContainer = "RootNodeTypeMustBeContainer";
         internal static readonly string NodeNameIsNullOrEmpty = "NodeNameIsNullOrEmpty";
         internal static readonly string NewDriveRootDoesNotExist = "NewDriveRootDoesNotExist";
-        internal static readonly string NotContainerNode = "NotContainerNode";      
+        internal static readonly string NotContainerNode = "NotContainerNode";
+        internal static readonly string NotSupported = "NotSupported";
     }
 
     internal static class Constants

--- a/test/automation/ctor.psm1
+++ b/test/automation/ctor.psm1
@@ -16,7 +16,7 @@ using namespace Microsoft.PowerShell.SHiPS
 $script:PowerShellProcessName = if($IsCoreCLR) {'pwsh'} else{ 'PowerShell'}
 
 
-# colision with .Net - should work
+# collision with .Net - should work
 class Environment : SHiPSDirectory
 {
 

--- a/test/automation/navigation.tests.ps1
+++ b/test/automation/navigation.tests.ps1
@@ -1174,7 +1174,7 @@ AfterEach{
 
        }
 
-    It "Test-Path - expect succeed" {
+     It "Test-Path - expect succeed" {
 
         $a= new-psdrive -name kk -psprovider SHiPS -root Test#Root
         $a.Name | Should Be "kk"
@@ -1209,7 +1209,132 @@ AfterEach{
         test-path .\Bill\BITS | Should be $True
         test-path .\Bill\BITS -Type Container | Should be $False
         test-path .\Bill\BITS -Type Leaf | Should be $True
-    }
+     }
        
  }
+
+Describe "Not Supported Commands test" -Tags "Feature"{
+BeforeEach{
+        cd $home
+        $a=Get-PSDrive -PSProvider SHiPS
+        $a | % {remove-psdrive $_.Name -ErrorAction Ignore}
+
+        $a = new-psdrive -name ss -psprovider SHiPS -root test#Root
+        $a.Name | Should Be "ss"
+
+        cd $testpath
+       }
+
+AfterEach{
+        cd $home
+        $a=Get-PSDrive -PSProvider SHiPS
+        $a | % {remove-psdrive $_.Name -ErrorAction Ignore}
+
+        If(Test-Path $script:homePath) {Remove-Item -Path $script:homePath -force -Recurse -ErrorAction Ignore}
+        
+        cd $testpath
+       }
+ 
+    It "ClearItem throws NotSupported" {
+        cd ss:\William;
+        $null = dir
+        Clear-Item -Path .\Chrisylin -ErrorAction SilentlyContinue -ErrorVariable ev
+        $ev.FullyQualifiedErrorId -match "NotSupported,Microsoft.PowerShell.Commands.ClearItemCommand" | Should Be $true
+       }
+
+    It "SetItem throws NotSupported" {
+        cd ss:\William
+        $null = dir
+        Set-Item -Path .\Chrisylin -Value "what" -ErrorAction SilentlyContinue -ErrorVariable ev
+        $ev.FullyQualifiedErrorId -match "NotSupported,Microsoft.PowerShell.Commands.SetItemCommand" | Should Be $true
+
+       }
+
+    It "MoveItem throws NotSupported" {
+           cd ss:
+           $b = dir ss:\William\Chrisylin
+           $b.GetType().Name -match "ChrisLeaf" | should be $true
+
+           $c = dir ss:\Bill
+           $c.Count -gt 1 | Should be $true
+
+           cd ss:\William
+           $null = dir
+           Move-Item -Path ss:\William\Chrisylin -Destination ss:\Bill -ErrorAction SilentlyContinue -ErrorVariable ev
+           $ev.FullyQualifiedErrorId -match "NotSupported,Microsoft.PowerShell.Commands.MoveItemCommand" | Should Be $true
+        }
+
+    It "CopyItem throws NotSupported" {
+        cd ss:
+        $b = dir ss:\William\Chrisylin
+        $b.GetType().Name -match "ChrisLeaf" | should be $true
+
+        $c = dir ss:\Bill
+        $c.Count -gt 1 | Should be $true
+
+        cd ss:\William
+        $null = dir
+        Copy-Item -Path ss:\William\Chrisylin -Destination ss:\Bill\ -ErrorAction SilentlyContinue -ErrorVariable ev
+        $ev.FullyQualifiedErrorId -match "NotSupported,Microsoft.PowerShell.Commands.CopyItemCommand" | Should Be $true
+       }
+
+    It "NewItem throws NotSupported" {
+        cd ss:\Bill
+        $null = dir
+        New-Item -Path .\newbie.txt -ItemType file -ErrorAction SilentlyContinue -ErrorVariable ev
+        $ev.FullyQualifiedErrorId -match "NotSupported,Microsoft.PowerShell.Commands.NewItemCommand" | Should Be $true
+       }
+
+    It "RemoveItem throws NotSupported" {
+        cd ss:
+        $b = dir ss:\William\Chrisylin
+        $b.GetType().Name -match "ChrisLeaf" | should be $true
+
+        cd ss:\William
+        $null = dir
+        Remove-Item -Path ss:\William\Chrisylin -ErrorAction SilentlyContinue -ErrorVariable ev
+        $ev.FullyQualifiedErrorId -match "NotSupported,Microsoft.PowerShell.Commands.RemoveItemCommand" | Should Be $true
+       }
+
+    It "RenameItem throws NotSupported" {
+        cd ss:
+        $b = dir ss:\William\Chrisylin
+        $b.GetType().Name -match "ChrisLeaf" | should be $true
+
+        cd ss:\William
+        $null = dir
+        Rename-Item -Path .\Chrisylin -NewName Christin -ErrorAction SilentlyContinue -ErrorVariable ev
+        $ev.FullyQualifiedErrorId -match "NotSupported,Microsoft.PowerShell.Commands.RenameItemCommand" | Should Be $true
+       }
+
+    It "Get-Content throws NotSupported" {
+        cd ss:\William
+        $b = dir .\Chrisylin
+        $b.Name | should be "Chrisylin"
+
+        $null = dir
+        Get-Content .\Chrisylin -ErrorAction SilentlyContinue -ErrorVariable ev
+        $ev.FullyQualifiedErrorId | Should Be "NotSupported,Microsoft.PowerShell.Commands.GetContentCommand"
+       }
+
+    It "Set-Content throws NotSupported" {
+        cd ss:\William
+        $b = dir .\Chrisylin
+        $b.Name | should be "Chrisylin"
+
+        "blabla" | Set-Content .\Chrisylin -ErrorAction SilentlyContinue -ErrorVariable ev
+        $ev.FullyQualifiedErrorId | Should Be "NotSupported,Microsoft.PowerShell.Commands.SetContentCommand"
+       }
+
+    It "Clear-Content throws NotSupported" {
+        cd ss:\William
+        $b = dir .\Chrisylin
+        $b.Name | should be "Chrisylin"
+
+        $null = dir
+        Clear-Content .\Chrisylin -ErrorAction SilentlyContinue -ErrorVariable ev
+        $ev.FullyQualifiedErrorId | Should Be "NotSupported,Microsoft.PowerShell.Commands.ClearContentCommand"
+    }
+}
+
   

--- a/vs2015/NodeServiceBase.cs
+++ b/vs2015/NodeServiceBase.cs
@@ -1,0 +1,109 @@
+﻿using System.Management.Automation;
+using System.Management.Automation.Provider;
+using CodeOwls.PowerShell.Provider.PathNodeProcessors;
+using CodeOwls.PowerShell.Provider.PathNodes;
+using Microsoft.PowerShell.SHiPS;
+using ProviderContext = CodeOwls.PowerShell.Provider.PathNodeProcessors.ProviderContext;
+
+namespace CodeOwls.PowerShell.Paths;
+
+namespace Microsoft.PowerShell.SHiPS
+{
+    /// <summary>
+    /// Defines actions that applies to a SHiPSLeaf node.
+    /// </summary>
+    internal class NodeServiceBase : PathNodeBase,
+        IGetItemContent,
+        ISetItemContent,
+        IClearItemContent
+    {
+        public override string Name
+        {
+            get { return _shipsNode.Name; }
+        }
+
+        public override IPathValue GetNodeValue()
+        {
+            return new PathValue(_shipsNode, Name, false);
+        }
+
+        private SHiPSBase _shipsNode;
+
+        internal NodeServiceBase(object shipsNode)
+        {
+            _shipsNode = shipsNode as SHiPSBase;
+        }
+
+        #region IContentCmdletProvider - Get/Set/Clear-Content
+        public void ClearContent(IProviderContext providerContext)
+        {
+            var cmdletContext = providerContext as ProviderContext;
+            GetNotSupportedMessage(cmdletContext);
+        }
+
+        public object ClearContentDynamicParameters(IProviderContext providerContext)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IContentWriter GetContentWriter(IProviderContext providerContext)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object GetContentWriterDynamicParameters(IProviderContext providerContext)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IContentReader GetContentReader(IProviderContext providerContext)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object GetContentReaderDynamicParameters(IProviderContext providerContext)
+        {
+            throw new System.NotImplementedException();
+        }
+        #endregion
+
+        #region private methods
+        /// <summary>
+        /// Compose the NotSupported Message.
+        /// </summary>
+        /// <param name="command">Command executed</param>
+        /// <param name="path">Path parameter of the command</param>
+        /// <returns>The Error Message</returns>
+        private string GetNotSupportedMessage(ProviderContext ctx)
+        {
+            var fullpath = ctx.Path?.Replace(ctx.Drive.Root, ctx.Drive.Name + ":");
+            return $"This operation is not supported in {ctx.Drive.Name} drive. Current path: {fullpath}";
+        }
+
+        /// <summary>
+        /// Get user friendly path.
+        /// </summary>
+        /// <param name="path">Full path in SHiPSProvider, e.g. AzurePSDrive#Azure\AuthMethods_EDOG</param>
+        /// <returns>User friendly path, e.g. Azure:\AuthMethods_EDOG</returns>
+        private string ReplaceDriveRootWithName(string path)
+        {
+            return path?.Replace(Drive.Root, DriveNameWithColon);
+        }
+
+        /// <summary>
+        /// WriteError of NotSupported. This will allow the cmdlet to continue execution.
+        /// </summary>
+        /// <param name="errorMessage">Error Message</param>
+        /// <param name="targetObject">Target Object</param>
+        private void WriteErrorNotImplemented(string errorMessage, object targetObject = null)
+        {
+            var ex = new PSNotSupportedException(errorMessage);
+            ErrorRecord er = new ErrorRecord(ex, ErrorId.NotSupported, ErrorCategory.NotImplemented, targetObject);
+
+            // WriteError will not terminate right away, so we can get handling of -ErrorVariable, -ErrorAction.
+            WriteError(er);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Add handling to not supported commands, throw NotSupport error to reduce confusion;

Add UnitTest for all of the not supported commands.

UnitTest passed in both Full PowerShell and PowerShell Core.