### PR TITLE
Add Credentials capability to SHiPSProvider

### DIFF
--- a/docs/PublicAPIsAndMore.md
+++ b/docs/PublicAPIsAndMore.md
@@ -95,6 +95,14 @@ The following properties are exposed to SHiPS' derived classes as protected memb
 
 - `ProviderContext`: provider's data
 
+  - `Drive`
+  Gets a [Drive][psdriveinfo] that current node originates from.
+  For example, author can use it to get acces to credentials provided by user in `-Credential` parameter of [`New-PSDrive`][new-psdrive] cmdlet.
+  
+    ```powershell
+    $credential = $this.ProviderContext.Drive.Credential
+    ```
+
   - `DynamicParameters`
   As above mentioned, an author can define dynamic parameters for their providers.
   To process whether a user uses these dyanmic parameters, author can access them via the following mechanism.
@@ -126,4 +134,6 @@ The following properties are exposed to SHiPS' derived classes as protected memb
     if(-not $this.ProviderContext.Force)
     ```
 
+[psdriveinfo]: https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.psdriveinfo
+[new-psdrive]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-psdrive
 [ds]:../samples/DynamicParameter

--- a/docs/PublicAPIsAndMore.md
+++ b/docs/PublicAPIsAndMore.md
@@ -95,12 +95,12 @@ The following properties are exposed to SHiPS' derived classes as protected memb
 
 - `ProviderContext`: provider's data
 
-  - `Drive`
-  Gets a [Drive][psdriveinfo] that current node originates from.
-  For example, author can use it to get acces to credentials provided by user in `-Credential` parameter of [`New-PSDrive`][new-psdrive] cmdlet.
+  - `DriveCredential`
+  Gets a [drive][psdriveinfo] [credential][pscredential] that was supplied by a user in `-Credential` parameter of [`New-PSDrive`][new-psdrive] cmdlet.
+  Author can use provided credential to get data from sources that requires authentication.
   
     ```powershell
-    $credential = $this.ProviderContext.Drive.Credential
+    $credential = $this.ProviderContext.DriveCredential
     ```
 
   - `DynamicParameters`
@@ -134,6 +134,7 @@ The following properties are exposed to SHiPS' derived classes as protected memb
     if(-not $this.ProviderContext.Force)
     ```
 
+[pscredential]: https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.pscredential
 [psdriveinfo]: https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.psdriveinfo
 [new-psdrive]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-psdrive
 [ds]:../samples/DynamicParameter

--- a/src/Microsoft.PowerShell.SHiPS/Node/ProviderContext.cs
+++ b/src/Microsoft.PowerShell.SHiPS/Node/ProviderContext.cs
@@ -11,11 +11,6 @@ namespace Microsoft.PowerShell.SHiPS
     public class ProviderContext
     {
         /// <summary>
-        /// Gets the drive property.
-        /// </summary>
-        public PSDriveInfo Drive { get; internal set; }
-
-        /// <summary>
         /// Gets the force property.
         /// </summary>
         public bool Force { get; internal set; }
@@ -35,22 +30,28 @@ namespace Microsoft.PowerShell.SHiPS
         /// </summary>
         public object DynamicParameters { get; internal set; }
 
+        /// <summary>
+        /// Gets the drive credential property.
+        /// </summary>
+        public PSCredential DriveCredential { get; internal set; }
+
         internal void Set(IProviderContext context)
         {
-            Drive = context.Drive;
             Force = context.Force;
             Recurse = context.Recurse;
             Filter = context.Filter;
             DynamicParameters = context.DynamicParameters;
+            PSDriveInfo drive = context.Drive;
+            DriveCredential = drive != null ? drive.Credential : PSCredential.Empty;
         }
 
         internal void Clear()
         {
-            Drive = null;
             Force = false;
             Recurse = false;
             Filter = null;
             DynamicParameters = null;
+            DriveCredential = null;
         }
     }
 }

--- a/src/Microsoft.PowerShell.SHiPS/Node/ProviderContext.cs
+++ b/src/Microsoft.PowerShell.SHiPS/Node/ProviderContext.cs
@@ -1,4 +1,5 @@
-﻿using CodeOwls.PowerShell.Paths.Extensions;
+﻿using System.Management.Automation;
+using CodeOwls.PowerShell.Paths.Extensions;
 using CodeOwls.PowerShell.Provider.PathNodeProcessors;
 
 namespace Microsoft.PowerShell.SHiPS
@@ -9,6 +10,11 @@ namespace Microsoft.PowerShell.SHiPS
     /// </summary>
     public class ProviderContext
     {
+        /// <summary>
+        /// Gets the drive property.
+        /// </summary>
+        public PSDriveInfo Drive { get; internal set; }
+
         /// <summary>
         /// Gets the force property.
         /// </summary>
@@ -31,6 +37,7 @@ namespace Microsoft.PowerShell.SHiPS
 
         internal void Set(IProviderContext context)
         {
+            Drive = context.Drive;
             Force = context.Force;
             Recurse = context.Recurse;
             Filter = context.Filter;
@@ -39,6 +46,7 @@ namespace Microsoft.PowerShell.SHiPS
 
         internal void Clear()
         {
+            Drive = null;
             Force = false;
             Recurse = false;
             Filter = null;

--- a/src/Microsoft.PowerShell.SHiPS/SHiPSProvider.cs
+++ b/src/Microsoft.PowerShell.SHiPS/SHiPSProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerShell.SHiPS
     /// Defines the implementation of a 'generic' PowerShell provider.  This provider
     /// allows for stateless namespace navigation of a system you are modeling.
     /// </summary>
-    [CmdletProvider(SHiPSProvider.ProviderName, ProviderCapabilities.Filter | ProviderCapabilities.ShouldProcess)]
+    [CmdletProvider(SHiPSProvider.ProviderName, ProviderCapabilities.Filter | ProviderCapabilities.ShouldProcess | ProviderCapabilities.Credentials)]
     public class SHiPSProvider : CodeOwls.PowerShell.Provider.Provider
     {
         public const string ProviderName = "SHiPS";

--- a/test/automation/test.psm1
+++ b/test/automation/test.psm1
@@ -535,6 +535,22 @@ class DynamicParameterKeyValuePairTraditional : SHiPSDirectory
 
 
 
+[SHiPSProvider(UseCache=$true)]
+class DriveCredentialTest : SHiPSDirectory
+{
+    DriveCredentialTest([string]$name): base($name)
+    {
+    }
+
+    [object[]] GetChildItem()
+    {
+        $credential = $this.ProviderContext.DriveCredential.GetNetworkCredential()
+        return @($credential.UserName, $credential.Password, [DriveCredentialTest]::new('child'))
+    }
+}
+
+
+
 class FilterTest : SHiPSDirectory
 {
 


### PR DESCRIPTION
Add `Credentials` capability to `SHiPSProvider` and add `Drive` property to `ProviderContext` (#110)