### PR TITLE
Update bootstrap.ps1 for PowerShell Core on Windows

### DIFF
--- a/src/bootstrap.ps1
+++ b/src/bootstrap.ps1
@@ -96,7 +96,7 @@ function Start-DotnetBootstrap
     }
 
     # Install for Windows
-    if ($IsWindows -and -not $IsCoreCLR) {
+    if ($IsWindows) {
         Remove-Item -ErrorAction SilentlyContinue -Recurse -Force ~\AppData\Local\Microsoft\dotnet
         $installScript = 'dotnet-install.ps1'
         Invoke-WebRequest -Uri $obtainUrl/$installScript -OutFile $installScript
@@ -105,9 +105,6 @@ function Start-DotnetBootstrap
         # Since we are downloading the installScript everytime, remove it after the run
         # to not create a diff in Git
         #Remove-Item $installScript -Verbose -Force
-
-    } elseif ($IsWindows) {
-        Write-Warning 'Start-DotnetBootstrap cannot be run in Core PowerShell on Windows (need Invoke-WebRequest!)'
     }
 }
 


### PR DESCRIPTION
When running bootstrap.ps1 on PowerShell Core on Windows, the following message is displayed:
```
Start-DotnetBootstrap cannot be run in Core PowerShell on Windows (need Invoke-WebRequest!)
```

But bootstrap.ps1 can be runnable on PowerShell Core on Windows because it has Invoke-WebRequest as a built-in cmdlet.

I have modified the `if` statement and tested it on the following environment:

```powershell
PS> $PSVersionTable

Name                           Value
----                           -----
PSVersion                      6.1.0
PSEdition                      Core
GitCommitId                    6.1.0
OS                             Microsoft Windows 10.0.17134
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```
