### PR TITLE
Fix README: `-root FileSystem#C` does not exist

### DIFF
--- a/samples/FileSystem/README.md
+++ b/samples/FileSystem/README.md
@@ -13,7 +13,7 @@ See the [FileSystem module][fs].
 ```powershell
 Import-Module  SHiPS
 Import-Module .\samples\FileSystem
-new-psdrive -name FS -psprovider SHiPS -root FileSystem#C
+New-PSDrive -Name FS -PSProvider SHiPS -Root FileSystem#Home
 cd FS:
 dir
 ```


### PR DESCRIPTION
The following command in FileSystem/README.md throws the error:
```
PS> new-psdrive -name FS -psprovider SHiPS -root FileSystem#C
New-PSDrive : Cannot create an instance of type 'C' in the module 'C:\Users\matt9ucci\SHiPS\samples\FileSystem\FileSystem.psm1'.
Make sure type 'C' exists, inherits from Microsoft.PowerShell.SHiPS.SHiPSDirectory, and Name is set in constructors.
As a root, a constructor 'C([string]$name)'  is required.
Fix the script and try again.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidOperation: (:) [New-PSDrive], InvalidOperationException
+ FullyQualifiedErrorId : CannotCreateInstance,Microsoft.PowerShell.Commands.NewPSDriveCommand
```

The `C` should be replaced with `Home` that exists in FileSystem.psm1.
