### PR TITLE
Suppress warnings about trying to import module without psd1 file

### DIFF
--- a/src/Microsoft.PowerShell.SHiPS/SHiPSDrive.cs
+++ b/src/Microsoft.PowerShell.SHiPS/SHiPSDrive.cs
@@ -80,9 +80,9 @@ namespace Microsoft.PowerShell.SHiPS
             var modulePath = Path.Combine((moduleBaseObj).ModuleBase, (moduleBaseObj).Name.TrimEnd() + ".psd1");
             if(!File.Exists(modulePath))
             {
-                _provider.WriteWarning(Resources.Resource.FileNotExist.StringFormat(modulePath));
+                _provider.WriteDebug(Resources.Resource.FileNotExist.StringFormat(modulePath));
                 modulePath = moduleBaseObj.Path;
-                _provider.WriteWarning(Resources.Resource.Trying.StringFormat(modulePath));
+                _provider.WriteDebug(Resources.Resource.Trying.StringFormat(modulePath));
             }
 
             _provider.WriteVerbose(modulePath);


### PR DESCRIPTION
If a provider module does not have *.psd1 file, warning messages are displayed by invoking `New-PSDrive` cmdlet:
```powershell
PS> New-PSDrive -Name Austin -PSProvider SHiPS -Root 'FamilyTree#Austin'
WARNING: 'C:\Users\matt9ucci\SHiPS\samples\FamilyTree\FamilyTree.psd1' does not exist.
WARNING: Trying 'C:\Users\matt9ucci\SHiPS\samples\FamilyTree\FamilyTree.psm1'.
```

These warning messages are somewhat noisy, especially when running unit tests with `Invoke-SHiPSTest` function in setup.psm1.

*.psd1 files are not required for a module (see the [official doc](https://docs.microsoft.com/en-us/powershell/developer/module/understanding-a-windows-powershell-module#module-manifests)). It would be better to change the log level from warning to debug.
