### PR TITLE
Update DynamicSample example documentation

### DIFF
--- a/samples/DynamicParameter/README.md
+++ b/samples/DynamicParameter/README.md
@@ -30,9 +30,9 @@ See the [DynamicParameterSample module][ds].
 
 ```powershell
    Import-Module  SHiPS
-   Import-Module  .\samples\DynamicParameterSample
+   Import-Module  .\samples\DynamicParameter
 
-   new-psdrive -name n -psprovider SHiPS -root DynamicParameterSample#Nature
+   new-psdrive -name n -psprovider SHiPS -root DynamicParameter#Nature
    cd n:
    dir
 


### PR DESCRIPTION
The DynamicSample example documentation incorrectly loads the wrong module script file, and therefore the
`New-PSDrive` command will fail.  This commit changes the example to use the correct text.