### PR TITLE
Set Pester MaximumVersion 4.10.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ init:
 
 # Install Pester
 install:
-    - cinst -y pester
+    - choco install pester --version=4.10.1 -y
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:

--- a/tools/setup.psm1
+++ b/tools/setup.psm1
@@ -178,7 +178,7 @@ function Invoke-SHiPSTest {
         $TestResultsFile = Microsoft.PowerShell.Management\Join-Path -Path $script:TestHome -ChildPath "TestResults.xml"
         if($script:PowerShellEdition -eq 'Core')
         {
-            & $PowerShellExePath -Command "`$env:PSModulePath ; `$PSVersionTable; `$ProgressPreference = 'SilentlyContinue';Install-Module Pester -force; Import-Module Pester; Invoke-Pester -Script $script:TestHome -OutputFormat NUnitXml -OutputFile $TestResultsFile"
+            & $PowerShellExePath -Command "`$env:PSModulePath ; `$PSVersionTable; `$ProgressPreference = 'SilentlyContinue';Install-Module Pester -MaximumVersion 4.10.1 -Force; Import-Module Pester -MaximumVersion 4.10.1 -Force; Invoke-Pester -Script $script:TestHome -OutputFormat NUnitXml -OutputFile $TestResultsFile"
         }
         else {
             & $PowerShellExePath -Command "`$env:PSModulePath ; `$PSVersionTable; `$ProgressPreference = 'SilentlyContinue'; Invoke-Pester -Script $script:TestHome -OutputFormat NUnitXml -OutputFile $TestResultsFile"


### PR DESCRIPTION
`Invoke-SHiPSTest` failed as follows:

```powershell
PS> Invoke-SHiPSTest
...
[-] Get and Set test.Get Set Tests 336ms (321ms|15ms)
 RuntimeException: Legacy Should syntax (without dashes) is not supported in Pester 5.
 Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
```

This is because `Invoke-SHiPSTest` installs Pester v5, the latest version, but current test cases are written as v3/4.

For a workaround, set the `-MaximumVersion` parameter [4.10.1](https://www.powershellgallery.com/packages/Pester/4.10.1), the latest version of v4.x.
(These test cases should be rewritten as v5 in the future.)
