### PR TITLE
Update .gitignore: dotnet-install.ps1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ artifacts/
 **/Properties/launchSettings.json
 
 # Auto generated
+src/dotnet-install.ps1
 tools/install-powershell.ps1
 packages/


### PR DESCRIPTION
Added the gitignore pattern for dotnet-install.ps1 downloaded by [bootstrap.ps1](https://github.com/PowerShell/SHiPS/blob/91762f57fab5725d58ee325c21b48c90ef6e57f0/src/bootstrap.ps1#L101-L102).